### PR TITLE
Add Mapbox plume map to Streamlit app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ psycopg2-binary
 python-dotenv
 pandas
 streamlit-aggrid==0.3.4.post3
+pydeck


### PR DESCRIPTION
## Summary
- show selected plume location on a hybrid Mapbox map with circle sized by CH4 rate
- add pydeck dependency for map rendering

## Testing
- `pip install --quiet -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af3ed6da4483309c2e145a530550d5