### PR TITLE
Add OpenAI web search for website resolution

### DIFF
--- a/tests/test_contact_scrapper.py
+++ b/tests/test_contact_scrapper.py
@@ -86,3 +86,24 @@ def test_resolve_website_uses_open_search(monkeypatch):
     )
     assert site == "https://operator.example"
 
+
+def test_resolve_website_uses_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    def fake_openai(query, logs, timeout=10):
+        return "https://operator.example"
+
+    monkeypatch.setattr(cs, "_openai_web_search_first_result", fake_openai)
+
+    logs = []
+    site = cs.resolve_website(
+        name="Five Sisters compressor station",
+        country="USA",
+        lat=None,
+        lon=None,
+        given_website="",
+        logs=logs,
+        search_provider="openai",
+    )
+    assert site == "https://operator.example"
+


### PR DESCRIPTION
## Summary
- integrate OpenAI web search into contact scraper to resolve company websites
- support `OPENAI_SEARCH_MODEL` env var with low-context web searches
- add tests covering OpenAI search provider

## Testing
- `pytest -q`
- `python -m py_compile contact_scraper.py tests/test_contact_scrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68af45ddc64c8330a96121a1f1d3bbb3