### PR TITLE
Configure Nginx to run as www-data

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,27 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+
+# Default error log path is /var/log/nginx/error.log
+# Default access log path is /var/log/nginx/access.log
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen       80 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add deploy/nginx.conf to run Nginx as the www-data user

## Testing
- `pytest`
- `docker build -t methane_nginx deploy` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2417653483309e8bb416ebce89c4